### PR TITLE
Update WinGet-AutoUpdate-Configurator.admx

### DIFF
--- a/ADMX/WinGet-AutoUpdate-Configurator.admx
+++ b/ADMX/WinGet-AutoUpdate-Configurator.admx
@@ -1,4 +1,4 @@
-﻿<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.04.0000" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
+﻿<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.04" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
 	<policyNamespaces>
 		<target prefix="WinGet-AutoUpdate-Configurator" namespace="WinGet-AutoUpdate-Configurator.Configuration.Policies"/>
 	</policyNamespaces>


### PR DESCRIPTION
revision="1.04.0000" is not valid. Corrected to revision="1.04".

# Proposed Changes

> revision="1.04.0000" is not valid. Corrected to revision="1.04".

## Related Issues

>https://github.com/Weatherlights/Winget-AutoUpdate-Intune/issues/7

[autolink-references]: https://github.com/Weatherlights/Winget-AutoUpdate-Intune/issues/7
