### PR TITLE
Update WinGet-AutoUpdate-Configurator.admx

### DIFF
--- a/ADMX/WinGet-AutoUpdate-Configurator.admx
+++ b/ADMX/WinGet-AutoUpdate-Configurator.admx
@@ -1,4 +1,4 @@
-﻿<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.04.0000" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
+﻿<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.04" xsi:schemaLocation="" schemaVersion="1.0" xmlns="http://www.microsoft.com/GroupPolicy/PolicyDefinitions">
 	<policyNamespaces>
 		<target prefix="WinGet-AutoUpdate-Configurator" namespace="WinGet-AutoUpdate-Configurator.Configuration.Policies"/>
 	</policyNamespaces>


### PR DESCRIPTION
Fixed https://github.com/Weatherlights/Winget-AutoUpdate-Intune/issues/10#issuecomment-1681086768

Settings won't appear in intune config profile creation!

Open the ADMX file and change the revision from "1.04.0000" to "1.04" the additional .0000 makes its fail on Import. Then reupload the new files to Intune. Someone needs to update it on GitHub.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
